### PR TITLE
fix: make one more page url to scrape

### DIFF
--- a/src/bot.ts
+++ b/src/bot.ts
@@ -1,5 +1,5 @@
 import 'dotenv/config.js';
-import { Post, crawl } from './crawler.ts';
+import { Posts, crawl } from './crawler.ts';
 import { getIssue, updateIssue } from './api/issue.ts';
 
 const BOT_TOKEN = process.env.TELEGRAM_BOT_TOKEN;
@@ -15,10 +15,10 @@ async function app() {
     const lastVolumeno = getLastVolumeno(issue.data.body);
     const newPosts = getNewPosts(postsFromCrawling, lastVolumeno);
 
-    if (newPosts.length > 0) {
+    if (newPosts.size > 0) {
       await sendNotification(newPosts);
 
-      const newPostsVolumeno = newPosts.map((post) => post.volumeno).join('\n');
+      const newPostsVolumeno = [...newPosts].map(([volumeno, value]) => volumeno).join('\n');
       await updateIssue({
         owner: 'eenaree',
         repo: 'keyeast-post-bot',
@@ -34,21 +34,23 @@ function getLastVolumeno(data: string) {
   return +volumenoList[volumenoList.length - 1];
 }
 
-function getNewPosts(posts: Post[], lastVolumeno: number) {
-  const newPosts: Post[] = [];
-  posts.forEach((post) => {
-    if (lastVolumeno < post.volumeno) {
-      newPosts.unshift(post);
+function getNewPosts(posts: Posts, lastVolumeno: number) {
+  const keyAscPostsArray = [...posts].sort();
+  const keyAscPostsMap = new Map(keyAscPostsArray);
+  const newPosts: Posts = new Map();
+  keyAscPostsMap.forEach((value, volumeno) => {
+    if (lastVolumeno < volumeno) {
+      newPosts.set(volumeno, value);
     }
   });
 
   return newPosts;
 }
 
-async function sendNotification(posts: Post[]) {
+async function sendNotification(posts: Posts) {
   try {
-    for (const post of posts) {
-      const text = encodeURIComponent(`${post.title}\n${post.link}`);
+    for (const [volumeno, { title, link }] of posts) {
+      const text = encodeURIComponent(`${title}\n${link}`);
       await fetch(
         `https://api.telegram.org/bot${BOT_TOKEN}/sendMessage?chat_id=${CHAT_ID}&text=${text}`
       );

--- a/src/bot.ts
+++ b/src/bot.ts
@@ -31,13 +31,13 @@ async function app() {
 
 function getLastVolumeno(data: string) {
   const volumenoList = data.split('\n');
-  return volumenoList[volumenoList.length - 1];
+  return +volumenoList[volumenoList.length - 1];
 }
 
-function getNewPosts(posts: Post[], lastVolumeno: string) {
+function getNewPosts(posts: Post[], lastVolumeno: number) {
   const newPosts: Post[] = [];
   posts.forEach((post) => {
-    if (+lastVolumeno < +post.volumeno) {
+    if (lastVolumeno < post.volumeno) {
       newPosts.unshift(post);
     }
   });

--- a/src/crawler.ts
+++ b/src/crawler.ts
@@ -1,11 +1,7 @@
 import puppeteer from 'puppeteer';
 import * as cheerio from 'cheerio';
 
-export type Post = {
-  title: string;
-  link: string;
-  volumeno: number;
-};
+export type Posts = Map<number, { title: string; link: string }>;
 
 function getPageUrl(keyword: string) {
   return `https://post.naver.com/search/authorPost.naver?keyword=${encodeURIComponent(
@@ -16,7 +12,7 @@ function getPageUrl(keyword: string) {
 export async function crawl() {
   const browser = await puppeteer.launch();
   const page1 = await browser.newPage();
-  const posts: Post[] = [];
+  const posts: Posts = new Map();
 
   try {
     await page1.goto(getPageUrl('문가영'));
@@ -38,7 +34,7 @@ export async function crawl() {
           let href = $(elem).find('a.link_end').attr('href');
           if (href) {
             href = href.slice(0, href.indexOf('&searchKeyword'));
-            posts.push({ volumeno, title, link: 'https://post.naver.com' + href });
+            posts.set(volumeno, { title, link: 'https://post.naver.com' + href });
           }
         }
       }
@@ -52,7 +48,7 @@ export async function crawl() {
   const page2 = await browser.newPage();
 
   try {
-    await page2.goto(getPageUrl('가영'));
+    await page2.goto(getPageUrl('문가영 광고'));
     await page2.setViewport({ width: 1920, height: 1080 });
   } catch (error) {
     throw new Error('failed to load the page2');
@@ -71,7 +67,7 @@ export async function crawl() {
           let href = $(elem).find('a.link_end').attr('href');
           if (href) {
             href = href.slice(0, href.indexOf('&searchKeyword'));
-            posts.push({ volumeno, title, link: 'https://post.naver.com' + href });
+            posts.set(volumeno, { title, link: 'https://post.naver.com' + href });
           }
         }
       }

--- a/src/crawler.ts
+++ b/src/crawler.ts
@@ -30,6 +30,7 @@ export async function crawl() {
     const $ = cheerio.load(content);
     const feedElems = $('ul.lst_feed').children();
     feedElems.each((i, elem) => {
+      if (i > 4) return;
       for (const attr of elem.attributes) {
         if (attr.name === 'volumeno') {
           const volumeno = +attr.value;
@@ -62,6 +63,7 @@ export async function crawl() {
     const $ = cheerio.load(content);
     const feedElems = $('ul.lst_feed').children();
     feedElems.each((i, elem) => {
+      if (i > 4) return;
       for (const attr of elem.attributes) {
         if (attr.name === 'volumeno') {
           const volumeno = +attr.value;

--- a/src/crawler.ts
+++ b/src/crawler.ts
@@ -7,23 +7,26 @@ export type Post = {
   volumeno: number;
 };
 
-const pageUrl =
-  'https://post.naver.com/search/authorPost.naver?keyword=%EB%AC%B8%EA%B0%80%EC%98%81&memberNo=29770009&sortType=createDate.dsc&navigationType=current';
+function getPageUrl(keyword: string) {
+  return `https://post.naver.com/search/authorPost.naver?keyword=${encodeURIComponent(
+    keyword
+  )}&memberNo=29770009&sortType=createDate.dsc`;
+}
 
 export async function crawl() {
   const browser = await puppeteer.launch();
-  const page = await browser.newPage();
+  const page1 = await browser.newPage();
   const posts: Post[] = [];
 
   try {
-    await page.goto(pageUrl);
-    await page.setViewport({ width: 1920, height: 1080 });
+    await page1.goto(getPageUrl('문가영'));
+    await page1.setViewport({ width: 1920, height: 1080 });
   } catch (error) {
-    throw new Error('failed to load the page');
+    throw new Error('failed to load the page1');
   }
 
   try {
-    const content = await page.content();
+    const content = await page1.content();
     const $ = cheerio.load(content);
     const feedElems = $('ul.lst_feed').children();
     feedElems.each((i, elem) => {
@@ -40,9 +43,41 @@ export async function crawl() {
       }
     });
   } catch (error) {
-    throw new Error('failed to extract posts from the page');
+    throw new Error('failed to extract posts from the page1');
   } finally {
-    await page.close();
+    await page1.close();
+  }
+
+  const page2 = await browser.newPage();
+
+  try {
+    await page2.goto(getPageUrl('가영'));
+    await page2.setViewport({ width: 1920, height: 1080 });
+  } catch (error) {
+    throw new Error('failed to load the page2');
+  }
+
+  try {
+    const content = await page2.content();
+    const $ = cheerio.load(content);
+    const feedElems = $('ul.lst_feed').children();
+    feedElems.each((i, elem) => {
+      for (const attr of elem.attributes) {
+        if (attr.name === 'volumeno') {
+          const volumeno = +attr.value;
+          const title = $(elem).find('.tit_feed').text().split('\t').join('').trim();
+          let href = $(elem).find('a.link_end').attr('href');
+          if (href) {
+            href = href.slice(0, href.indexOf('&searchKeyword'));
+            posts.push({ volumeno, title, link: 'https://post.naver.com' + href });
+          }
+        }
+      }
+    });
+  } catch {
+    throw new Error('failed to extract posts from the page2');
+  } finally {
+    await page2.close();
     await browser.close();
   }
 

--- a/src/crawler.ts
+++ b/src/crawler.ts
@@ -1,4 +1,4 @@
-import puppeteer from 'puppeteer';
+import puppeteer, { Browser } from 'puppeteer';
 import * as cheerio from 'cheerio';
 
 export type Posts = Map<number, { title: string; link: string }>;
@@ -11,18 +11,34 @@ function getPageUrl(keyword: string) {
 
 export async function crawl() {
   const browser = await puppeteer.launch();
-  const page1 = await browser.newPage();
+
+  try {
+    const [postsPage1, postsPage2] = await Promise.all([
+      scrapePage(browser, '문가영'),
+      scrapePage(browser, '가영'),
+    ]);
+    const mergedPosts = new Map([...postsPage1, ...postsPage2]);
+    return mergedPosts;
+  } catch (error) {
+    throw new Error('failed to scrape the page');
+  } finally {
+    await browser.close();
+  }
+}
+
+async function scrapePage(browser: Browser, keyword: string) {
+  const page = await browser.newPage();
   const posts: Posts = new Map();
 
   try {
-    await page1.goto(getPageUrl('문가영'));
-    await page1.setViewport({ width: 1920, height: 1080 });
+    await page.goto(getPageUrl(keyword));
+    await page.setViewport({ width: 1920, height: 1080 });
   } catch (error) {
-    throw new Error('failed to load the page1');
+    throw new Error(`failed to load the page: keyword ${keyword}`);
   }
 
   try {
-    const content = await page1.content();
+    const content = await page.content();
     const $ = cheerio.load(content);
     const feedElems = $('ul.lst_feed').children();
     feedElems.each((i, elem) => {
@@ -39,45 +55,10 @@ export async function crawl() {
         }
       }
     });
+    return posts;
   } catch (error) {
-    throw new Error('failed to extract posts from the page1');
+    throw new Error(`failed to extract posts from the page: keyword ${keyword}`);
   } finally {
-    await page1.close();
+    await page.close();
   }
-
-  const page2 = await browser.newPage();
-
-  try {
-    await page2.goto(getPageUrl('문가영 광고'));
-    await page2.setViewport({ width: 1920, height: 1080 });
-  } catch (error) {
-    throw new Error('failed to load the page2');
-  }
-
-  try {
-    const content = await page2.content();
-    const $ = cheerio.load(content);
-    const feedElems = $('ul.lst_feed').children();
-    feedElems.each((i, elem) => {
-      if (i > 4) return;
-      for (const attr of elem.attributes) {
-        if (attr.name === 'volumeno') {
-          const volumeno = +attr.value;
-          const title = $(elem).find('.tit_feed').text().split('\t').join('').trim();
-          let href = $(elem).find('a.link_end').attr('href');
-          if (href) {
-            href = href.slice(0, href.indexOf('&searchKeyword'));
-            posts.set(volumeno, { title, link: 'https://post.naver.com' + href });
-          }
-        }
-      }
-    });
-  } catch {
-    throw new Error('failed to extract posts from the page2');
-  } finally {
-    await page2.close();
-    await browser.close();
-  }
-
-  return posts;
 }


### PR DESCRIPTION
- Fixes #3 

## 변경사항
1. 기존의 키워드 '문가영' 외에 '가영'을 검색한 최신순 페이지 결과를 더 추가하고, 빠르게 결과를 얻기 위해 병렬적으로 실행하도록 함

2. 실제 하루에 업로드 되는 포스트의 개수는 1~2개이기 때문에, 스크랩 할 포스트의 개수 역시 키워드별로 최대 5개로 제한함
(최신순으로 정렬된 포스트 검색 결과에서 모든 포스트를 가져올 필요가 없다고 판단)